### PR TITLE
Getting latest release version from github repository

### DIFF
--- a/Editor/BootstrapperConfig.cs
+++ b/Editor/BootstrapperConfig.cs
@@ -8,16 +8,14 @@ namespace Com.OneSignal.Bootstrapper
         public static readonly string BootstrapperPackageName = $"{OneSignalScope}.unity.bootstrap";
 
         public static readonly string OneSignalCoreName = $"{OneSignalScope}.unity.core";
-        public static readonly string OneSignalCoreVersion = "0.0.4-preview";
-
         public static readonly string OneSignalIOSName = $"{OneSignalScope}.unity.ios";
-        public static readonly string OneSignalIosVersion = "0.0.4-preview";
-
         public static readonly string OneSignalAndroidName = $"{OneSignalScope}.unity.android";
-        public static readonly string OneSignalAndroidVersion = "0.0.4-preview";
 
         public static readonly string GoogleScopeRegistryUrl = "https://unityregistry-pa.googleapis.com";
         public static readonly string NpmjsScopeRegistryUrl = "https://registry.npmjs.org/";
+
+        public const string GitHubRepositoryURL = @"ssh://git@github.com:StansAssets/OneSignal-Unity-SDK.git";
+        public const string BootstrapperFolderPath = @"Assets/OneSignalBootstrap";
 
         public static ScopeRegistry GoogleScopeRegistry =>
             new ScopeRegistry("Game Package Registry by Google",

--- a/Editor/BootstrapperTestWindow.cs
+++ b/Editor/BootstrapperTestWindow.cs
@@ -1,0 +1,30 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    public class BootstrapperTestWindow : EditorWindow
+    {
+        static Label s_LatestVersionLabel;
+
+        [MenuItem("OneSignalBootstrap/TestWindow")]
+        static void Init ()
+        {
+            var window = (BootstrapperTestWindow)EditorWindow.GetWindow (typeof (BootstrapperTestWindow));
+            window.Show();   
+        }
+        
+        void OnEnable ()
+        {
+            rootVisualElement.Clear ();
+            rootVisualElement.Add (new Button (CleanUpUtility.RemoveBootstrapperAssets) {text = "Clean Up"});
+            rootVisualElement.Add (new Button (() => Bootstrapper.InstallLatestOneSignalRelease (false)) {text = "Install OneSignal Packages (no cleanup)"});
+            rootVisualElement.Add (new Button (() => Bootstrapper.InstallLatestOneSignalRelease (true)) {text = "Install OneSignal Packages (complete)"});
+            
+            rootVisualElement.Add (s_LatestVersionLabel ?? (s_LatestVersionLabel = new Label ("latest package version is unknown")));
+            rootVisualElement.Add (new Button (() => GitHubUtility.GetLatestRelease (BootstrapperConfig.GitHubRepositoryURL,
+                                                                                     release => s_LatestVersionLabel.text = $"latest package version is {release.Name}"))
+                                   { text = "Load latest package version" });
+        }
+    }
+}

--- a/Editor/BootstrapperTestWindow.cs.meta
+++ b/Editor/BootstrapperTestWindow.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9dea83e48d0248f9a16c092dd2e7fefe
+timeCreated: 1615542266

--- a/Editor/Core/GitHubRelease.cs
+++ b/Editor/Core/GitHubRelease.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using OneSignalPush.MiniJSON;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    class GitHubRelease
+    {
+        internal string Name { get; }
+        internal string Tag { get; }
+
+        internal GitHubRelease (string json)
+        {
+            Name = FindValueByKey ("name", json);
+            Tag = FindValueByKey ("tag_name", json);
+        }
+
+        string FindValueByKey (string key, string json)
+        {
+            // number of characters from the 1st char of the given key to the 1st char of corresponding value
+            int offsetBeforeValue = key.Length + 5;
+            string lookForString = $"\"{key}\"";
+            int position = json.IndexOf (lookForString, StringComparison.InvariantCulture) + offsetBeforeValue;
+            var value = (position > offsetBeforeValue) 
+                            ? new string(json.Skip (position).TakeWhile (c => c != '"').ToArray ()) 
+                            : string.Empty;
+            return value;
+        }
+    }
+}

--- a/Editor/Core/GitHubRelease.cs.meta
+++ b/Editor/Core/GitHubRelease.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ae4e4ed5b10f9b44dbfb86263c730332
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utilities/CleanUpUtility.cs
+++ b/Editor/Utilities/CleanUpUtility.cs
@@ -1,0 +1,27 @@
+using UnityEditor;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    static class CleanUpUtility
+    {
+        internal static void RemoveBootstrapperAssets ()
+        {
+            if (AssetDatabase.IsValidFolder (BootstrapperConfig.BootstrapperFolderPath))
+            {
+#if UNITY_2020
+                var failedPathsList = new List<string>();
+                if (!AssetDatabase.DeleteAssets (new[]{BootstrapperConfig.BootstrapperFolderPath}, failedPathsList)){
+                    failedPathsList.ForEach(Debug.Log);
+                }
+                else {
+                    Debug.Log ($"Folder {RemovalPath} not found!");
+                }
+#else
+                FileUtil.DeleteFileOrDirectory(BootstrapperConfig.BootstrapperFolderPath);
+                FileUtil.DeleteFileOrDirectory(BootstrapperConfig.BootstrapperFolderPath + ".meta");
+                AssetDatabase.Refresh();
+#endif
+            }
+        }
+    }
+}

--- a/Editor/Utilities/CleanUpUtility.cs.meta
+++ b/Editor/Utilities/CleanUpUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0fddc5e042c4ed0b89e34d50f8a8858
+timeCreated: 1615563149

--- a/Editor/Utilities/GitHubUtility.cs
+++ b/Editor/Utilities/GitHubUtility.cs
@@ -1,0 +1,27 @@
+using System;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Com.OneSignal.Bootstrapper
+{
+    static class GitHubUtility
+    {
+        internal static void GetLatestRelease (string url, Action<GitHubRelease> callback)
+        {
+            var rq = UnityWebRequest.Get (GetReleaseInfoURL (url));
+            rq.SendWebRequest ().completed += obj => {
+                callback (new GitHubRelease (rq.downloadHandler.text));
+            };
+        }
+
+        static string GetReleaseInfoURL (string repositoryURL)
+        {
+            if (repositoryURL.Contains ("github.com")) {
+                return repositoryURL.Replace (@".git", @"/releases/latest")
+                                    .Replace (@"ssh://git@github.com:", @"https://api.github.com/repos/");
+            }
+            
+            throw new InvalidOperationException($"The provided URL {repositoryURL} is not a GitHub repository URL.");
+        }
+    }
+}

--- a/Editor/Utilities/GitHubUtility.cs.meta
+++ b/Editor/Utilities/GitHubUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54e1af83b23e31840ba67b75104e4348
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/lock.meta
+++ b/Editor/lock.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 09728594bd6e4dfd941a51177939f3aa
+timeCreated: 1615564317


### PR DESCRIPTION
The Bootstrapper downloads the latest release version of packages instead of a predefined one
Added a lock file that prevents an execution of the Bootstrapper